### PR TITLE
Code style improvements

### DIFF
--- a/Source/Formatters/FORMFloatFormatter.h
+++ b/Source/Formatters/FORMFloatFormatter.h
@@ -2,4 +2,6 @@
 
 @interface FORMFloatFormatter : FORMFormatter
 
+- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse formatter:(NSNumberFormatter *)formatter;
+
 @end

--- a/Source/Formatters/FORMFloatFormatter.h
+++ b/Source/Formatters/FORMFloatFormatter.h
@@ -2,6 +2,8 @@
 
 @interface FORMFloatFormatter : FORMFormatter
 
-- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse formatter:(NSNumberFormatter *)formatter;
+- (NSString *)formatString:(NSString *)string
+                   reverse:(BOOL)reverse
+                 formatter:(NSNumberFormatter *)formatter;
 
 @end

--- a/Source/Formatters/FORMFloatFormatter.m
+++ b/Source/Formatters/FORMFloatFormatter.m
@@ -2,15 +2,27 @@
 
 @implementation FORMFloatFormatter
 
-- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse {
+- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse formatter:(NSNumberFormatter *)formatter {
     string = [super formatString:string reverse:reverse];
     if (!string) return nil;
+    string = [string stringByReplacingOccurrencesOfString:@"." withString:formatter.decimalSeparator];
 
+    NSNumber *number = [formatter numberFromString:string];
+  
     if (reverse) {
-        return [string stringByReplacingOccurrencesOfString:@"," withString:@"."];
+        [formatter setNumberStyle:NSNumberFormatterNoStyle];
     } else {
-        return [string stringByReplacingOccurrencesOfString:@"." withString:@","];
+        [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
     }
+    string = [formatter stringFromNumber:number];
+    return string;
+}
+
+- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse {
+  NSNumberFormatter *formatter = [NSNumberFormatter new];
+  formatter.positiveFormat = @"###.##";
+  formatter.decimalSeparator = @",";
+  return [self formatString:string reverse:reverse formatter:formatter];
 }
 
 @end

--- a/Source/Formatters/FORMFloatFormatter.m
+++ b/Source/Formatters/FORMFloatFormatter.m
@@ -2,27 +2,30 @@
 
 @implementation FORMFloatFormatter
 
-- (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse formatter:(NSNumberFormatter *)formatter {
+- (NSString *)formatString:(NSString *)string
+                   reverse:(BOOL)reverse
+                 formatter:(NSNumberFormatter *)formatter {
     string = [super formatString:string reverse:reverse];
     if (!string) return nil;
-    string = [string stringByReplacingOccurrencesOfString:@"." withString:formatter.decimalSeparator];
+
+    string = [string stringByReplacingOccurrencesOfString:@"."
+                                               withString:formatter.decimalSeparator];
 
     NSNumber *number = [formatter numberFromString:string];
-  
-    if (reverse) {
-        [formatter setNumberStyle:NSNumberFormatterNoStyle];
-    } else {
-        [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
-    }
+    formatter.numberStyle = (reverse) ? NSNumberFormatterNoStyle : NSNumberFormatterDecimalStyle;
     string = [formatter stringFromNumber:number];
+
     return string;
 }
 
 - (NSString *)formatString:(NSString *)string reverse:(BOOL)reverse {
-  NSNumberFormatter *formatter = [NSNumberFormatter new];
-  formatter.positiveFormat = @"###.##";
-  formatter.decimalSeparator = @",";
-  return [self formatString:string reverse:reverse formatter:formatter];
+    NSNumberFormatter *formatter = [NSNumberFormatter new];
+    formatter.positiveFormat = @"###.##";
+    formatter.decimalSeparator = @",";
+
+    return [self formatString:string
+                      reverse:reverse
+                    formatter:formatter];
 }
 
 @end

--- a/Source/Input Validators/FORMFloatInputValidator.m
+++ b/Source/Input Validators/FORMFloatInputValidator.m
@@ -9,11 +9,11 @@
     if (!valid) return valid;
 
     BOOL hasDelimiter = ([text hyp_containsString:@","] || [text hyp_containsString:@"."]);
-    BOOL stringIsNilOrComma = (!string || [string isEqualToString:@","]);
+    BOOL stringIsNilOrDelimiter = (!string || [string isEqualToString:@","] || [string isEqualToString:@"."]);
 
-    if (hasDelimiter && stringIsNilOrComma) return NO;
+    if (hasDelimiter && stringIsNilOrDelimiter) return NO;
 
-    NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString:@"1234567890,"];
+    NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString:@"1234567890,."];
     NSCharacterSet *stringSet = [NSCharacterSet characterSetWithCharactersInString:string];
 
     return [floatSet isSupersetOfSet:stringSet];

--- a/Source/Input Validators/FORMFloatInputValidator.m
+++ b/Source/Input Validators/FORMFloatInputValidator.m
@@ -3,20 +3,28 @@
 
 @implementation FORMFloatInputValidator
 
-- (BOOL)validateReplacementString:(NSString *)string withText:(NSString *)text withRange:(NSRange)range {
-    BOOL valid = [super validateReplacementString:string withText:text withRange:range];
-
+- (BOOL)validateReplacementString:(NSString *)string
+                         withText:(NSString *)text
+                        withRange:(NSRange)range {
+    BOOL valid = [super validateReplacementString:string
+                                         withText:text
+                                        withRange:range];
     if (!valid) return valid;
 
-    BOOL hasDelimiter = ([text hyp_containsString:@","] || [text hyp_containsString:@"."]);
-    BOOL stringIsNilOrDelimiter = (!string || [string isEqualToString:@","] || [string isEqualToString:@"."]);
+    BOOL hasDelimiter = ([text hyp_containsString:@","] ||
+                         [text hyp_containsString:@"."]);
+    BOOL stringIsNilOrDelimiter = (!string ||
+                                   [string isEqualToString:@","] ||
+                                   [string isEqualToString:@"."]);
+    if (hasDelimiter && stringIsNilOrDelimiter) {
+        valid = NO;
+    } else {
+        NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString:@"1234567890,."];
+        NSCharacterSet *stringSet = [NSCharacterSet characterSetWithCharactersInString:string];
+        valid = [floatSet isSupersetOfSet:stringSet];
+    }
 
-    if (hasDelimiter && stringIsNilOrDelimiter) return NO;
-
-    NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString:@"1234567890,."];
-    NSCharacterSet *stringSet = [NSCharacterSet characterSetWithCharactersInString:string];
-
-    return [floatSet isSupersetOfSet:stringSet];
+    return valid;
 }
 
 @end

--- a/Source/Models/FORMField.h
+++ b/Source/Models/FORMField.h
@@ -36,6 +36,10 @@ typedef NS_ENUM(NSInteger, FORMFieldType) {
 @property (nonatomic) BOOL initiallyDisabled;
 @property (nonatomic) NSDate *minimumDate;
 @property (nonatomic) NSDate *maximumDate;
+@property (nonatomic) NSString *positiveFormat;
+@property (nonatomic) NSString *negativeFormat;
+@property (nonatomic) NSString *groupingSeparator;
+@property (nonatomic) NSString *decimalSeparator;
 
 @property (nonatomic) FORMFieldValidation *validation;
 @property (nonatomic) NSString *formula;

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -36,6 +36,17 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
     _type = [self typeFromTypeString:self.typeString];
     _inputTypeString = [dictionary andy_valueForKey:@"input_type"];
     _info = [dictionary andy_valueForKey:@"info"];
+  
+    _positiveFormat = [dictionary andy_valueForKey:@"positive_format"];
+    if (!_positiveFormat) {
+      _positiveFormat = @"###.##";
+    }
+    _negativeFormat = [dictionary andy_valueForKey:@"negative_format"];
+    _groupingSeparator = [dictionary andy_valueForKey:@"grouping_separator"];
+    _decimalSeparator = [dictionary andy_valueForKey:@"decimal_separator"];
+    if (!_decimalSeparator) {
+      _decimalSeparator = @",";
+    }
 
     NSNumber *width = [dictionary andy_valueForKey:@"size.width"] ?: @100;
     NSNumber *height = [dictionary andy_valueForKey:@"size.height"]?: @1;
@@ -153,7 +164,7 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
     switch (self.type) {
         case FORMFieldTypeFloat:
             if ([self.value isKindOfClass:[NSString class]]) {
-                self.value = [self.value stringByReplacingOccurrencesOfString:@"," withString:@"."];
+                self.value = [self.value stringByReplacingOccurrencesOfString:@"." withString:self.decimalSeparator];
             }
             return @([self.value floatValue]);
         case FORMFieldTypeNumber:

--- a/Source/Models/FORMFieldValue.h
+++ b/Source/Models/FORMFieldValue.h
@@ -11,6 +11,10 @@
 @property (nonatomic) FORMField *field;
 @property (nonatomic) NSNumber *value;
 @property (nonatomic) BOOL defaultValue;
+@property (nonatomic) NSString *positiveFormat;
+@property (nonatomic) NSString *negativeFormat;
+@property (nonatomic) NSString *groupingSeparator;
+@property (nonatomic) NSString *decimalSeparator;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 

--- a/Source/Models/FORMFieldValue.m
+++ b/Source/Models/FORMFieldValue.m
@@ -15,6 +15,10 @@
     _info = [dictionary andy_valueForKey:@"info"];
     _value = [dictionary andy_valueForKey:@"value"];
     _defaultValue = [[dictionary andy_valueForKey:@"default"] boolValue];
+    _positiveFormat = [dictionary andy_valueForKey:@"positive_format"];
+    _negativeFormat = [dictionary andy_valueForKey:@"negative_format"];
+    _groupingSeparator = [dictionary andy_valueForKey:@"grouping_separator"];
+    _decimalSeparator = [dictionary andy_valueForKey:@"decimal_separator"];
 
     NSMutableArray *targets = [NSMutableArray new];
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		44713C611AE8E9DC00AA97DA /* simple-number-field.json in Resources */ = {isa = PBXBuildFile; fileRef = 44713C601AE8E9DC00AA97DA /* simple-number-field.json */; };
 		44932E771AE79BBD00A159BE /* simple-section.json in Resources */ = {isa = PBXBuildFile; fileRef = 44932E761AE79BBD00A159BE /* simple-section.json */; };
 		4496E4961AE7913400F731C9 /* simple-text-field.json in Resources */ = {isa = PBXBuildFile; fileRef = 4496E4951AE7913400F731C9 /* simple-text-field.json */; };
+		7AA39F8E1B039CF900EF0222 /* FORMFloatFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AA39F8D1B039CF900EF0222 /* FORMFloatFormatterTests.m */; };
 		8EC9C8158643C507F883EEC4 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E09ABAE07DB25A266537B76 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		BD2405701AE6B38D00592E19 /* default-values-in-template.json in Resources */ = {isa = PBXBuildFile; fileRef = BD24056F1AE6B38D00592E19 /* default-values-in-template.json */; };
 		BD5845751AC4074600596C62 /* FORMTooltipView.m in Sources */ = {isa = PBXBuildFile; fileRef = BD5845741AC4074600596C62 /* FORMTooltipView.m */; };
@@ -231,6 +232,7 @@
 		4496E4951AE7913400F731C9 /* simple-text-field.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "simple-text-field.json"; sourceTree = "<group>"; };
 		4E09ABAE07DB25A266537B76 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		653AC6BBDF66E205BA44BA17 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		7AA39F8D1B039CF900EF0222 /* FORMFloatFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMFloatFormatterTests.m; sourceTree = "<group>"; };
 		BD24056F1AE6B38D00592E19 /* default-values-in-template.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "default-values-in-template.json"; sourceTree = "<group>"; };
 		BD5845731AC4074600596C62 /* FORMTooltipView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FORMTooltipView.h; sourceTree = "<group>"; };
 		BD5845741AC4074600596C62 /* FORMTooltipView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMTooltipView.m; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 			isa = PBXGroup;
 			children = (
 				D5B56C091AE52F8500DD8816 /* FORMEmailFormatterTests.m */,
+				7AA39F8D1B039CF900EF0222 /* FORMFloatFormatterTests.m */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -740,6 +743,7 @@
 				144A28D31A99B2CF004A9086 /* FORMBankAccountNumberInputValidator.m in Sources */,
 				144A28BD1A99B2CF004A9086 /* FORMDateFieldCell.m in Sources */,
 				14298D6E1ADDA78F00607A49 /* FORMValidatorTests.m in Sources */,
+				7AA39F8E1B039CF900EF0222 /* FORMFloatFormatterTests.m in Sources */,
 				149C29261A9A23DD00F88B91 /* FORMTargetTests.m in Sources */,
 				446C42661AF8B38F0002DFE9 /* FORMViewController.m in Sources */,
 				144A28DE1A99B2CF004A9086 /* FORMFieldValue.m in Sources */,

--- a/Tests/Tests/FORMFieldValueTests.m
+++ b/Tests/Tests/FORMFieldValueTests.m
@@ -13,12 +13,20 @@
                                                                               @"title": @"Contract Type",
                                                                               @"info": @"This is ma' contract",
                                                                               @"value": @1,
+                                                                              @"positive_format": @"#,###.00",
+                                                                              @"negative_format": @"-#,###.00",
+                                                                              @"grouping_separator": @",",
+                                                                              @"decimal_separator": @".",
                                                                               @"default": @YES}];
     XCTAssertNotNil(fieldValue);
     XCTAssertEqualObjects(fieldValue.valueID, @"contract_type");
     XCTAssertEqualObjects(fieldValue.title, @"Contract Type");
     XCTAssertEqualObjects(fieldValue.info, @"This is ma' contract");
     XCTAssertEqualObjects(fieldValue.value, @1);
+    XCTAssertEqualObjects(fieldValue.positiveFormat, @"#,###.00");
+    XCTAssertEqualObjects(fieldValue.negativeFormat, @"-#,###.00");
+    XCTAssertEqualObjects(fieldValue.groupingSeparator, @",");
+    XCTAssertEqualObjects(fieldValue.decimalSeparator, @".");
     XCTAssertTrue(fieldValue.defaultValue);
 
     fieldValue = [[FORMFieldValue alloc] initWithDictionary:@{@"id": @0,

--- a/Tests/Tests/Formatters/FORMFloatFormatterTests.m
+++ b/Tests/Tests/Formatters/FORMFloatFormatterTests.m
@@ -10,28 +10,44 @@
 
 - (void)testFormatString {
     FORMFloatFormatter *formatter = [FORMFloatFormatter new];
-    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123,45" reverse:NO]);
-    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123.45" reverse:NO]);
-  
+    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123,45"
+                                                     reverse:NO]);
+    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123.45"
+                                                     reverse:NO]);
+
     NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
     numberFormatter.positiveFormat = @"###.##";
     numberFormatter.decimalSeparator = @",";
-    XCTAssertEqualObjects(@"123", [formatter formatString:@"123,00" reverse:NO formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123", [formatter formatString:@"123,00"
+                                                  reverse:NO
+                                                formatter:numberFormatter]);
 
     numberFormatter.positiveFormat = @"###.00";
-    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123,00" reverse:NO formatter:numberFormatter]);
-    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123.00" reverse:NO formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123,00"
+                                                     reverse:NO
+                                                   formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123.00"
+                                                     reverse:NO
+                                                   formatter:numberFormatter]);
 
     numberFormatter.decimalSeparator = @".";
     numberFormatter.groupingSeparator = @",";
-    XCTAssertEqualObjects(@"123.40", [formatter formatString:@"123.40" reverse:NO formatter:numberFormatter]);
-  
+    XCTAssertEqualObjects(@"123.40", [formatter formatString:@"123.40"
+                                                     reverse:NO
+                                                   formatter:numberFormatter]);
+
     numberFormatter.positiveFormat = @"#,###.00";
-    XCTAssertEqualObjects(@"1,123.00", [formatter formatString:@"1123.00" reverse:NO formatter:numberFormatter]);
-    XCTAssertEqualObjects(@"123,456,789.00", [formatter formatString:@"123456789.00" reverse:NO formatter:numberFormatter]);
-  
+    XCTAssertEqualObjects(@"1,123.00", [formatter formatString:@"1123.00"
+                                                       reverse:NO
+                                                     formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123,456,789.00", [formatter formatString:@"123456789.00"
+                                                             reverse:NO
+                                                           formatter:numberFormatter]);
+
     numberFormatter.positiveFormat = @"$#,###.00";
-    XCTAssertEqualObjects(@"$123,456,789.00", [formatter formatString:@"123456789.00" reverse:NO formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"$123,456,789.00", [formatter formatString:@"123456789.00"
+                                                              reverse:NO
+                                                            formatter:numberFormatter]);
 }
 
 @end

--- a/Tests/Tests/Formatters/FORMFloatFormatterTests.m
+++ b/Tests/Tests/Formatters/FORMFloatFormatterTests.m
@@ -10,8 +10,28 @@
 
 - (void)testFormatString {
     FORMFloatFormatter *formatter = [FORMFloatFormatter new];
-    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123,00" reverse:NO]);
-    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123.00" reverse:NO]);
+    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123,45" reverse:NO]);
+    XCTAssertEqualObjects(@"123,45", [formatter formatString:@"123.45" reverse:NO]);
+  
+    NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
+    numberFormatter.positiveFormat = @"###.##";
+    numberFormatter.decimalSeparator = @",";
+    XCTAssertEqualObjects(@"123", [formatter formatString:@"123,00" reverse:NO formatter:numberFormatter]);
+
+    numberFormatter.positiveFormat = @"###.00";
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123,00" reverse:NO formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123.00" reverse:NO formatter:numberFormatter]);
+
+    numberFormatter.decimalSeparator = @".";
+    numberFormatter.groupingSeparator = @",";
+    XCTAssertEqualObjects(@"123.40", [formatter formatString:@"123.40" reverse:NO formatter:numberFormatter]);
+  
+    numberFormatter.positiveFormat = @"#,###.00";
+    XCTAssertEqualObjects(@"1,123.00", [formatter formatString:@"1123.00" reverse:NO formatter:numberFormatter]);
+    XCTAssertEqualObjects(@"123,456,789.00", [formatter formatString:@"123456789.00" reverse:NO formatter:numberFormatter]);
+  
+    numberFormatter.positiveFormat = @"$#,###.00";
+    XCTAssertEqualObjects(@"$123,456,789.00", [formatter formatString:@"123456789.00" reverse:NO formatter:numberFormatter]);
 }
 
 @end

--- a/Tests/Tests/Formatters/FORMFloatFormatterTests.m
+++ b/Tests/Tests/Formatters/FORMFloatFormatterTests.m
@@ -1,0 +1,17 @@
+@import XCTest;
+
+#import "FORMFloatFormatter.h"
+
+@interface FORMFloatFormatterTests : XCTestCase
+
+@end
+
+@implementation FORMFloatFormatterTests
+
+- (void)testFormatString {
+    FORMFloatFormatter *formatter = [FORMFloatFormatter new];
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123,00" reverse:NO]);
+    XCTAssertEqualObjects(@"123,00", [formatter formatString:@"123.00" reverse:NO]);
+}
+
+@end


### PR DESCRIPTION
Made a few code style improvements, you might not seen this because there are a few places that we haven't audited.
- Required use of `{}` for `if` statements
- Newlines after every method parameter
- Methods that return a value should have one return at the end of the implementation, not multiple
- Returned values should be placed on a newline

:)
